### PR TITLE
BE | Create `UsersController#create`, `UserSerializer`, User model/migrations, `#create_api_key` User callback

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.new(user_params)
+    if user.save
+      render json: UserSerializer.new(user), status: :created
+    else
+      render json: { errors: error_message(user.errors) }, status: :bad_request
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::API
+
+  private
+
+  def error_message(errors)
+    errors.full_messages.join(", ")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,12 @@ class User < ApplicationRecord
   validates :password, presence: true, confirmation: true
 
   has_secure_password
+
+  before_create :create_api_key
+
+  private
+
+  def create_api_key
+    self.api_key = SecureRandom.hex(13)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  validates :email, presence: true, uniqueness: true
+  validates :password, presence: true, confirmation: true
+
+  has_secure_password
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include JSONAPI::Serializer
+  attributes :email, :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      get '/forecast', to: 'forecast#index'
+      resources :forecast, only: [:index]
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20230424013236_create_users.rb
+++ b/db/migrate/20230424013236_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :api_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_04_24_013236) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email) }
+    it { should validate_presence_of(:password) }
+    it { should validate_confirmation_of(:password) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,5 +6,16 @@ RSpec.describe User, type: :model do
     it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password) }
     it { should validate_confirmation_of(:password) }
+    it { should have_secure_password }
+  end
+
+  describe 'Password encryption' do
+    it 'encrypts the password using BCrypt' do
+      user = User.create(email: 'meg@test.com', password: 'password123', password_confirmation: 'password123')
+        expect(user).to_not have_attribute(:password)
+        expect(user).to_not have_attribute(:password_confirmation)
+        expect(user.password_digest).to_not be_nil
+        expect(user.password_digest).to_not eq('password123')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,4 +18,16 @@ RSpec.describe User, type: :model do
         expect(user.password_digest).to_not eq('password123')
     end
   end
+
+  describe 'instance methods' do
+    describe '#create_api_key' do
+      it 'creates an api key for the user in a callback' do
+        user = User.create(email: 'bob@test.com', password: 'password123', password_confirmation: 'password123')
+
+        expect(user.api_key).to_not be_nil
+        expect(user.api_key).to be_a(String)
+        expect(user.api_key.length).to eq(26)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Users API' do
+  context '#create' do
+    before do
+      user_1 = User.create(email: 'john@fake.com', password: 'password', password_confirmation: 'password')
+      user_2 = User.create(email: 'jim@fake.com', password: 'password2', password_confirmation: 'password2')
+      user_3 = User.create(email: 'jake@fake.com', password: 'password3', password_confirmation: 'password3')
+    end
+
+    context 'when successful' do
+      it 'creates a user' do
+        expect(User.count).to eq(3)
+
+        user_params = {
+          email: 'bobby@fake.com',
+          password: 'password4',
+          password_confirmation: 'password4'
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        post '/api/v1/users', headers: headers, params: user_params, as: :json
+        new_user = User.last
+
+        expect(response).to have_http_status(201)
+
+        user = JSON.parse(response.body, symbolize_names: true)
+
+        expect(user[:data]).to be_a(Hash)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -24,10 +24,77 @@ RSpec.describe 'Users API' do
         new_user = User.last
 
         expect(response).to have_http_status(201)
+        expect(User.count).to eq(4)
 
         user = JSON.parse(response.body, symbolize_names: true)
 
         expect(user[:data]).to be_a(Hash)
+        expect(user[:data].keys).to eq([:id, :type, :attributes])
+        expect(user[:data][:id]).to eq(new_user.id.to_s)
+        expect(user[:data][:type]).to eq('user')
+        expect(user[:data][:attributes].keys).to_not include(:password, :password_confirmation)
+        expect(user[:data][:attributes].keys).to eq([:email, :api_key])
+        expect(user[:data][:attributes][:email]).to eq(new_user.email)
+        expect(user[:data][:attributes][:api_key]).to eq(new_user.api_key)
+      end
+    end
+
+    context 'when unsuccessful' do
+      it 'returns an error if email is already taken' do
+        expect(User.count).to eq(3)
+
+        duplicate_params = {
+          email: 'john@fake.com',
+          password: 'password4',
+          password_confirmation: 'password4'
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        post '/api/v1/users', headers: headers, params: duplicate_params, as: :json
+        parsed = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(400)
+        expect(User.count).to eq(3)
+        expect(parsed[:errors]).to eq('Email has already been taken')
+      end
+
+      it 'returns an error if passwords do not match' do
+        expect(User.count).to eq(3)
+
+        mismatched_params = {
+          email: 'bogus@fake.com',
+          password: 'password4',
+          password_confirmation: 'password5'
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        post '/api/v1/users', headers: headers, params: mismatched_params, as: :json
+        parsed = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(400)
+        expect(User.count).to eq(3)
+        expect(parsed[:errors]).to eq("Password confirmation doesn't match Password, Password confirmation doesn't match Password")
+      end
+
+      it 'returns an error if email or password are missing' do
+        expect(User.count).to eq(3)
+
+        missing_params = {
+          email: ' ',
+          password: ' ',
+          password_confirmation: ' '
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        post '/api/v1/users', headers: headers, params: missing_params, as: :json
+        parsed = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(400)
+        expect(User.count).to eq(3)
+        expect(parsed[:errors]).to eq("Email can't be blank, Password can't be blank")
       end
     end
   end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -2,11 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Users API' do
   context '#create' do
-    before do
-      user_1 = User.create(email: 'john@fake.com', password: 'password', password_confirmation: 'password')
-      user_2 = User.create(email: 'jim@fake.com', password: 'password2', password_confirmation: 'password2')
-      user_3 = User.create(email: 'jake@fake.com', password: 'password3', password_confirmation: 'password3')
-    end
+    let!(:user_1) { User.create(email: 'john@fake.com', password: 'password', password_confirmation: 'password') }
+    let!(:user_2) { User.create(email: 'jim@fake.com', password: 'password2', password_confirmation: 'password2') }
+    let!(:user_3) { User.create(email: 'jake@fake.com', password: 'password3', password_confirmation: 'password3') }
 
     context 'when successful' do
       it 'creates a user' do
@@ -36,6 +34,9 @@ RSpec.describe 'Users API' do
         expect(user[:data][:attributes].keys).to eq([:email, :api_key])
         expect(user[:data][:attributes][:email]).to eq(new_user.email)
         expect(user[:data][:attributes][:api_key]).to eq(new_user.api_key)
+        expect(user[:data][:attributes][:api_key]).to_not eq(user_1.api_key)
+        expect(user[:data][:attributes][:api_key]).to_not eq(user_2.api_key)
+        expect(user[:data][:attributes][:api_key]).to_not eq(user_3.api_key)
       end
     end
 

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Users API' do
     let!(:user_3) { User.create(email: 'jake@fake.com', password: 'password3', password_confirmation: 'password3') }
 
     context 'when successful' do
-      it 'creates a user' do
+      it 'creates a user and an api key for them' do
         expect(User.count).to eq(3)
 
         user_params = {
@@ -16,7 +16,7 @@ RSpec.describe 'Users API' do
           password_confirmation: 'password4'
         }
 
-        headers = { 'CONTENT_TYPE' => 'application/json' }
+        headers = { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
 
         post '/api/v1/users', headers: headers, params: user_params, as: :json
         new_user = User.last
@@ -50,7 +50,7 @@ RSpec.describe 'Users API' do
           password_confirmation: 'password4'
         }
 
-        headers = { 'CONTENT_TYPE' => 'application/json' }
+        headers = { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
 
         post '/api/v1/users', headers: headers, params: duplicate_params, as: :json
         parsed = JSON.parse(response.body, symbolize_names: true)
@@ -69,7 +69,7 @@ RSpec.describe 'Users API' do
           password_confirmation: 'password5'
         }
 
-        headers = { 'CONTENT_TYPE' => 'application/json' }
+        headers = { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
 
         post '/api/v1/users', headers: headers, params: mismatched_params, as: :json
         parsed = JSON.parse(response.body, symbolize_names: true)
@@ -88,7 +88,7 @@ RSpec.describe 'Users API' do
           password_confirmation: ' '
         }
 
-        headers = { 'CONTENT_TYPE' => 'application/json' }
+        headers = { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
 
         post '/api/v1/users', headers: headers, params: missing_params, as: :json
         parsed = JSON.parse(response.body, symbolize_names: true)

--- a/spec/services/mapquest_service_spec.rb
+++ b/spec/services/mapquest_service_spec.rb
@@ -8,6 +8,7 @@ describe MapquestService do
         response = MapquestService.get_coordinates(location)
 
         expect(response).to be_a(Hash)
+        expect(response[:results][0][:providedLocation][:location]).to eq("Denver,CO")
         expect(response[:results][0][:locations][0][:latLng]).to have_key(:lat)
         expect(response[:results][0][:locations][0][:latLng]).to have_key(:lng)
         expect(response[:results][0][:locations][0][:latLng][:lat]).to be_a(Float)
@@ -23,6 +24,7 @@ describe MapquestService do
         response = MapquestService.get_coordinates(location)
 
         expect(response).to be_a(Hash)
+        expect(response[:results][0][:providedLocation][:location]).to eq("Los Angeles,CA")
         expect(response[:results][0][:locations][0][:latLng]).to have_key(:lat)
         expect(response[:results][0][:locations][0][:latLng]).to have_key(:lng)
         expect(response[:results][0][:locations][0][:latLng][:lat]).to be_a(Float)


### PR DESCRIPTION
Changes

- Create `UsersController#create`, `UserSerializer`, User model/migrations, `User#create_api_key` instance method callback, error handling method in `ApplicationController`
- Test for everything above
- More details in commits